### PR TITLE
Patch for XSS vulnerability in the log view.

### DIFF
--- a/content/content.logs.php
+++ b/content/content.logs.php
@@ -140,7 +140,7 @@
 						$adjusted = __('None');
 						$adjusted_class = 'inactive';
 					}
-					
+
 					$row[] = Widget::TableData(htmlentities($adjusted, ENT_QUOTES), $adjusted_class);
 					$row[] = Widget::TableData($log['results']);
 					$row[] = Widget::TableData($log['depth']);


### PR DESCRIPTION
Unescaped data on the log view page opens up an XSS vulnerability. I have added a htmlentities() call prior to the page render. This ensures the search data is escaped when viewing the logs but is unmodified for other functionality (ie: CSV export).

Please refer to: Issue #15
